### PR TITLE
Fix bug in -fsymbol-fixup feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This script is the culmination of three patches supporting decompilation with th
 2) Certain C++ symbols cannot be assembled normally.
    To support the buildsystem, a simple substitution system has been devised
 
-   ?<ID> -> CHAR
+   $<ID> -> CHAR
 
    IDs (all irregular symbols in mangled names):
       0: <
@@ -22,6 +22,8 @@ This script is the culmination of three patches supporting decompilation with th
       3: \\
       4: ,
       5: -
+      6: *
+      7: .
 
    This option is enabled with `-fsymbol-fixup`, and disabled by default with `-fno-symbol-fixup`
 

--- a/postprocess.py
+++ b/postprocess.py
@@ -122,7 +122,8 @@ SHT_STRTAB = 3
 
 def impl_postprocess_elf(f, do_ctor_realign, do_old_stack, do_symbol_fixup):
     result = []
-
+    strtab_sh_offset = -1
+    
     f.seek(0x20)
     ofsSecHeader = read_u32(f)
     f.seek(0x30)
@@ -244,7 +245,6 @@ def impl_postprocess_elf(f, do_ctor_realign, do_old_stack, do_symbol_fixup):
                     
                     f.seek(blr_pos - 4)
                     write_u32(f, mtlr)
-
     return (result, patch_align_ofs, strtab_sh_offset)
 
 class SymName:


### PR DESCRIPTION
This is a fix for an oversight I found in postprocess.py:

If a module contains a symbol whose name is the suffix of another symbol, the GNU assembler saves space by not storing the suffix separately in .strtab. Instead, the suffix symbol's `st_name` field just points into the middle of the full string.  So, if we shorten the part of the string that comes before the suffix, we corrupt its symbol's `st_name` field, even if we pad the end of the string with NUL bytes.

With this fix, the postprocessor will shift any affected `st_name` fields to their new correct position.  And with these changes, I was able to build Brawl successfully.